### PR TITLE
fix: 与 useRightContent 的 initialState.avatar 重名

### DIFF
--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -61,7 +61,7 @@ const BasicLayout = (props: any) => {
       menu={{ locale: userConfig.locale }}
       menuDataRender={() => menus}
       formatMessage={formatMessage}
-      logo={initialState?.avatar || logo}
+      logo={initialState?.logo || logo}
       menuItemRender={(menuItemProps, defaultDom) => {
         if (menuItemProps.isUrl || menuItemProps.children) {
           return defaultDom;


### PR DESCRIPTION
与 useRightContent 的 initialState.avatar 重名，导致设置 logo 时，右侧头像也跟着变，此处应为 logo