### PR TITLE
featrue: 添加自定义Layout渲染逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ export const layout = {
 - Type: (children) => React.ReactNode
 用于对内容区做自定义的包裹处理，将 children 作为参数传给此函数。
 
+**layoutRender**
+- Type: (proLayout, children) => React.ReactNode
+
+用户对整个Layout进行自定义渲染，proLayout表示当前默认执行的布局渲染，包含children对象。
+
 ## 路由配置
 Layout 插件会基于 [umi 的配置式路由](https://umijs.org/zh/guide/router.html#%E9%85%8D%E7%BD%AE%E5%BC%8F%E8%B7%AF%E7%94%B1)，封装了更多的配置项，支持更多配置式的能力。新增：
 

--- a/example/.umirc.ts
+++ b/example/.umirc.ts
@@ -4,6 +4,7 @@ import { IConfig } from 'umi-types';
 export default {
   routes: [
     { path: '/', component: './index', name: '测试', icon: 'home' },
+    { path: '/login', component: './login', name: '退出系统'},
   ],
   disableCSSModules: true,
   plugins: [

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -27,4 +27,12 @@ export const layout = {
       </>
     );
   },
+  layoutRender: (proLayout, children) => {
+
+    const location = window.location
+    if (location.pathname === '/login'){
+      return children;
+    }
+    return proLayout;
+  }
 };

--- a/example/pages/login.tsx
+++ b/example/pages/login.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Login = () => {
+    return <div> 这是一个登入页面，所以不需要布局信息。</div>
+}
+
+export default Login;

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -46,8 +46,7 @@ const BasicLayout = (props: any) => {
   if (currentPathConfig && currentPathConfig.hideNav) {
     layoutRender.headerRender = false;
   }
-
-  return (
+  const proLayout = (
     <ProLayout
       title={userConfig.name || userConfig.title}
       className="umi-plugin-layout-main"
@@ -85,6 +84,10 @@ const BasicLayout = (props: any) => {
       </ErrorBoundary>
     </ProLayout>
   );
+  if (userConfig.layoutRender) {
+    return userConfig.layoutRender(proLayout, children)
+  }
+  return proLayout;
 };
 
 export default BasicLayout;


### PR DESCRIPTION
## 更新描述

添加一个`layoutRender`属性，来控制对layout的渲染逻辑，进行自定义layout渲染。

## 相关的Issues
close https://github.com/umijs/plugin-layout/issues/8 
close https://github.com/umijs/plugin-layout/issues/4 

## 示意图

![演示](https://user-images.githubusercontent.com/24241052/79724168-a7271980-8319-11ea-9469-bcbcf9506897.gif)

## 使用例子

https://github.com/umijs/plugin-layout/pull/9/files#diff-9ec3645d16452bcb7cc3e71372e0f654R30-R37